### PR TITLE
fix: use pkg-config to source liquid-dsp dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install dependencies (brew)
       run: brew install meson libsndfile liquid-dsp
+    - name: Setup pkg-config path
+      run: echo "PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
     - name: meson setup
       run: meson setup -Dwerror=true build
     - name: meson compile

--- a/meson.build
+++ b/meson.build
@@ -38,17 +38,8 @@ sndfile = dependency('sndfile')
 
 # Find liquid-dsp
 if build_machine.system() == 'darwin'
-  fs = import('fs')
-  # Homebrew system
-  if fs.is_dir('/opt/homebrew/lib')
-    liquid_lib = cc.find_library('liquid', dirs: ['/opt/homebrew/lib'])
-    liquid_inc = include_directories('/opt/homebrew/include')
-    # MacPorts system
-  else
-    liquid_lib = cc.find_library('liquid', dirs: ['/opt/local/lib'])
-    liquid_inc = include_directories('/opt/local/include')
-  endif
-  liquid = declare_dependency(dependencies: liquid_lib, include_directories: liquid_inc)
+  # Use pkg-config for liquid-dsp on macOS
+  liquid = dependency('liquid', required: true)
 else
   liquid = cc.find_library('liquid')
 endif


### PR DESCRIPTION
Hi! Thank you for sharing this project, works great!

I was having an issue since meson.build was looking for Homebrew libraries in specific places (mine are in `/usr/local/Cellar/`)

This should address that issue.